### PR TITLE
feat: Add route to find an event by it's transaction id

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ let client = new Client('api_key')
 ### Events
 [Api reference](https://doc.getlago.com/docs/api/events)
 
+#### Push an event
+
 ``` javascript
 import Event from 'lago-nodejs-client/event'
 
@@ -34,6 +36,16 @@ let event = new Event(
 )
 
 await client.createEvent(event);
+```
+
+#### Find an event by its transaction_id
+
+``` javascript
+import Event from 'lago-nodejs-client/event'
+
+let transactionId = 'transactionId';
+
+let event = await client.findEvent(transactionId);
 ```
 
 ### Customers

--- a/lib/client.js
+++ b/lib/client.js
@@ -75,6 +75,14 @@ export default class Client {
         return response;
     }
 
+    async findEvent(transactionId){
+        let response;
+        await this-this.apiRequest(`/events/${transactionId}`, 'get')
+            .then(res => response = res.event);
+
+        return response;
+    }
+
     async createCustomer(inputCustomer){
         let response;
         await this.apiRequest(`/customers`, 'post', inputCustomer.wrapAttributes())

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -39,3 +39,34 @@ describe('Status code is not 2xx', () => {
         }
     });
 });
+
+describe('Succefully find an event', () => {
+    before(() => {
+        nock.cleanAll()
+        nock('https://api.getlago.com')
+            .get('/api/v1/events/transaction_id')
+            .reply(200, {})
+    });
+
+    it('returns response', async () => {
+        let response = await client.findEvent('transaction_id')
+        expect(response).to.be
+    })
+});
+
+describe('Error when finding an event', () => {
+    before(() => {
+        nock.cleanAll()
+        nock('https://api.getlago.com')
+            .get('/api/v1/events/transaction_id')
+            .reply(404)
+    });
+
+    it('raises an exception', async () => {
+        try {
+            await client.findEvent('transaction_id')
+        } catch (err) {
+            expect(err.message).to.eq(errorMessage)
+        }
+    });
+});


### PR DESCRIPTION
Following recent introduction of the event find route on lago api (https://github.com/getlago/lago-api/pull/269), this PR aims to replicate the update of the ruby client (https://github.com/getlago/lago-ruby-client/pull/16)