### PR TITLE
feat: synchronous stripe customer creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ let customer = new Customer(
     None,  // zipcode
     new BillingConfiguration(
         "stripe",
-        "cus_12345"
+        "cus_12345",
+        false
     )
 )
 await client.createCustomer(customer);

--- a/lib/models/billing_configuration.js
+++ b/lib/models/billing_configuration.js
@@ -1,10 +1,12 @@
 export default class BillingConfiguration {
   constructor(
     paymentProvider = null,
-    providerCustomerId = null
+    providerCustomerId = null,
+    sync = null
   ) {
     this.paymentProvider = paymentProvider,
-    this.providerCustomerId = providerCustomerId
+    this.providerCustomerId = providerCustomerId,
+    this.sync = sync
   }
 
   wrapAttributes = function() {
@@ -15,6 +17,9 @@ export default class BillingConfiguration {
 
     if (this.providerCustomerId != undefined)
         result.provider_customer_id = this.providerCustomerId;
+
+    if (this.sync != undefined)
+      result.sync = this.sync;
 
     return result;
   }


### PR DESCRIPTION
Add a new sync flag in customer[billing_configuration] in order to allow synchronous creation of the stripe customer. It will return the stripe customer ID immediately rather by waiting for the webhook