### PR TITLE
feat: Add new customer current usage route

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ let customer = new Customer(
 await client.createCustomer(customer);
 ```
 
+```javascript
+let customerUsage = await client.customerCurrentUsage('customer_id')
+```
+
 ### Subscriptions
 [Api reference](https://doc.getlago.com/docs/api/subscriptions/subscription-object)
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -91,6 +91,14 @@ export default class Client {
         return response;
     }
 
+    async customerCurrentUsage(customerId){
+        let response;
+        await this.apiRequest(`/customers/${customerId}/current_usage`, 'get')
+            .then(res => response = res.customer_usage);
+
+        return response;
+    }
+
     async updateInvoiceStatus(input){
         let body = {
             invoice: {
@@ -129,7 +137,7 @@ export default class Client {
         let response;
         await this.apiRequest(`/webhooks/public_key`, 'get').then(res => response = res);
 
-        let buff = new Buffer(response, 'base64');
+        let buff = new Buffer.from(response, 'base64');
         let key = buff.toString('ascii');
 
         return key;

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -57,3 +57,37 @@ describe('Status code is not 2xx', () => {
         }
     });
 });
+
+describe('Current usage responds with a 2xx', () => {
+    before(() => {
+        nock.cleanAll()
+        nock('https://api.getlago.com')
+            .get('/api/v1/customers/customer_id/current_usage')
+            .reply(200, {});
+    });
+
+    it('returns response', async () => {
+        let response = await client.customerCurrentUsage('customer_id')
+
+        expect(response).to.be
+    });
+});
+
+describe('Current usage responds with other than 2xx', () => {
+    let errorMessage = 'The HTTP status of the response: 404, URL: https://api.getlago.com/api/v1/customers/customer_id/current_usage'
+
+    before(() => {
+        nock.cleanAll()
+        nock('https://api.getlago.com')
+            .get('/api/v1/customers/customer_id/current_usage')
+            .reply(404);
+    });
+
+    it('raises an exception', async () => {
+        try {
+            await client.customerCurrentUsage('customer_id')
+        } catch (err) {
+            expect(err.message).to.eq(errorMessage)
+        }
+    });
+});


### PR DESCRIPTION
Add new `GET /api/v1/customers/:customer_id/current_usage` route

Related to:
- https://github.com/getlago/lago-api/pull/322
- https://github.com/getlago/lago-docs/pull/15