### PR TITLE
feat: Allow billing_time attribute for subscription creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ let subscription = new Subscription({
     customerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     planCode: "code",
     name: "name",
-    uniqueId: "id"
+    uniqueId: "id",
+    billingTime: "anniversary"
 })
+
 await client.createSubscription(subscription);
 
 await client.updateSubscription(new Subscription({name: 'new name'}), 'id');

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -21,6 +21,9 @@ export default class Subscription {
         if (this.attributes.uniqueId !== undefined && this.attributes.uniqueId !== null)
             subscription_object.unique_id = this.attributes.uniqueId;
 
+        if (this.attributes.billingTime !== undefined && this.attributes.billingTime !== null)
+            subscription_object.billingTime = this.attributes.billingTime;
+
         let result = {
             subscription: subscription_object
         };

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -5,7 +5,7 @@ import Subscription from '../lib/models/subscription.js';
 
 let client = new Client('api_key')
 let subscription = new Subscription(
-    {customerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", uniqueId: '123'}
+    {customerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", uniqueId: '123', billingTime: 'anniversary'}
 )
 
 describe('Successfully sent subscription responds with 2xx', () => {


### PR DESCRIPTION
## Context

We want to add the ability to choose to bill users at subscription date anniversary and not only on a calendar basis.

## Changes

The objective of this pull request is to add the support for `billing_time` attribute for subscription creation

Possible values will be `anniversary` and `calendar`

The changes are :
- Accept the new `billing_time` argument into 'POST /subscriptions'

## Related resources

This PR follows:
- https://github.com/getlago/lago-api/pull/352 to update the subscription data model.
- https://github.com/getlago/lago-api/pull/360 to add a new date service for invoice bounds
- https://github.com/getlago/lago-api/pull/364 to expose billing time into GraphQL
- https://github.com/getlago/lago-api/pull/365 to expose billing time into API