### PR TITLE
misc: Use external_id instead of customer_id and subscription_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import Event from 'lago-nodejs-client/event'
 import BatchEvent from 'lago-nodejs-client/batch_event'
 
 let event = new Event({
-      customerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+      externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
       transactionId: "__UNIQUE_TRANSACTION_ID__",
       code: "code",
       timestamp: 1650893379,
@@ -66,7 +66,7 @@ let event = await client.findEvent(transactionId);
 import Customer from 'lago-nodejs-client/customer'
 
 let customer = new Customer(
-    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",  // customerId
+    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",  // externalId
     None,  // addressLine1
     None,  // addressLine2
     None,  // city
@@ -91,7 +91,7 @@ await client.createCustomer(customer);
 ```
 
 ```javascript
-let customerUsage = await client.customerCurrentUsage('customer_id', 'subscription_id')
+let customerUsage = await client.customerCurrentUsage('external_customer_id', 'subscription_id')
 ```
 
 ### Subscriptions
@@ -101,20 +101,19 @@ let customerUsage = await client.customerCurrentUsage('customer_id', 'subscripti
 import Subscription from 'lago-nodejs-client/subscription'
 
 let subscription = new Subscription({
-    customerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     planCode: "code",
     name: "name",
-    uniqueId: "id",
     billingTime: "anniversary"
 })
 
 await client.createSubscription(subscription);
 
-await client.updateSubscription(new Subscription({name: 'new name'}), 'id');
+await client.updateSubscription(new Subscription({name: 'new name'}), 'external_id');
 
-await client.destroySubscription('id');
+await client.destroySubscription('external_id');
 
-await client.findAllSubscriptions({customer_id: '123'});
+await client.findAllSubscriptions({external_customer_id: '123'});
 ```
 
 ### Invoices
@@ -141,7 +140,7 @@ await client.downloadInvoice("5eb02857-a71e-4ea2-bcf9-57d8885990ba")
 import AppliedCoupon from 'lago-nodejs-client/applied_coupon'
 
 let appliedCoupon = new AppliedCoupon(
-    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",  // customerId
+    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",  // externalCustomerId
     "code"  // couponCode
 )
 await client.applyCoupon(appliedCoupon);
@@ -154,7 +153,7 @@ await client.applyCoupon(appliedCoupon);
 import AppliedAddOn from 'lago-nodejs-client/applied_add_on'
 
 let appliedAddOn = new AppliedAddOn(
-    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",  // customerId
+    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",  // externalCustomerId
     "code"  // addOnCode
 )
 await client.applyAddOn(appliedAddOn);

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ let event = new Event({
 await client.createEvent(event);
 
 let batchEvent = new BatchEvent({
-      subscriptionIds: ["5eb02857-a71e-4ea2-bcf9-57d8885990ba", "75e02857-a71e-4ea2-bcf9-57d8885990ba"],
+      externalSubscriptionIds: ["5eb02857-a71e-4ea2-bcf9-57d8885990ba", "75e02857-a71e-4ea2-bcf9-57d8885990ba"],
       transactionId: "__UNIQUE_TRANSACTION_ID__",
       code: "code",
       timestamp: 1650893379,
@@ -91,7 +91,7 @@ await client.createCustomer(customer);
 ```
 
 ```javascript
-let customerUsage = await client.customerCurrentUsage('external_customer_id', 'subscription_id')
+let customerUsage = await client.customerCurrentUsage('external_customer_id', 'external_subscription_id')
 ```
 
 ### Subscriptions

--- a/lib/client.js
+++ b/lib/client.js
@@ -103,9 +103,9 @@ export default class Client {
         return response;
     }
 
-    async customerCurrentUsage(customerId, subscriptionId){
+    async customerCurrentUsage(externalCustomerId, subscriptionId){
         let response;
-        await this.apiRequest(`/customers/${customerId}/current_usage?subscription_id=${subscriptionId}`, 'get')
+        await this.apiRequest(`/customers/${externalCustomerId}/current_usage?subscription_id=${subscriptionId}`, 'get')
             .then(res => response = res.customer_usage);
 
         return response;

--- a/lib/client.js
+++ b/lib/client.js
@@ -103,9 +103,9 @@ export default class Client {
         return response;
     }
 
-    async customerCurrentUsage(externalCustomerId, subscriptionId){
+    async customerCurrentUsage(externalCustomerId, externalSubscriptionId){
         let response;
-        await this.apiRequest(`/customers/${externalCustomerId}/current_usage?subscription_id=${subscriptionId}`, 'get')
+        await this.apiRequest(`/customers/${externalCustomerId}/current_usage?external_subscription_id=${externalSubscriptionId}`, 'get')
             .then(res => response = res.customer_usage);
 
         return response;

--- a/lib/models/applied_add_on.js
+++ b/lib/models/applied_add_on.js
@@ -1,11 +1,11 @@
 export default class AppliedAddOn {
     constructor(
-        customerId,
+        externalCustomerId,
         addOnCode,
         amountCents = null,
         amountCurrency = null
     ) {
-        this.customerId = customerId,
+        this.externalCustomerId = externalCustomerId,
         this.addOnCode = addOnCode,
         this.amountCents = amountCents,
         this.amountCurrency = amountCurrency
@@ -14,7 +14,7 @@ export default class AppliedAddOn {
     wrapAttributes = function () {
         let result = {
             applied_add_on: {
-                customer_id: this.customerId,
+                external_customer_id: this.externalCustomerId,
                 add_on_code: this.addOnCode,
                 amount_cents: this.amountCents,
                 amount_currency: this.amountCurrency

--- a/lib/models/applied_coupon.js
+++ b/lib/models/applied_coupon.js
@@ -1,11 +1,11 @@
 export default class AppliedCoupon {
     constructor(
-        customerId,
+        externalCustomerId,
         couponCode,
         amountCents = null,
         amountCurrency = null
     ) {
-        this.customerId = customerId,
+        this.externalCustomerId = externalCustomerId,
         this.couponCode = couponCode,
         this.amountCents = amountCents,
         this.amountCurrency = amountCurrency
@@ -14,7 +14,7 @@ export default class AppliedCoupon {
     wrapAttributes = function () {
         let result = {
             applied_coupon: {
-                customer_id: this.customerId,
+                externalCustomerId: this.externalCustomerId,
                 coupon_code: this.couponCode,
                 amount_cents: this.amountCents,
                 amount_currency: this.amountCurrency

--- a/lib/models/batch_event.js
+++ b/lib/models/batch_event.js
@@ -9,8 +9,8 @@ export default class BatchEvent {
         if (this.attributes.transactionId !== undefined && this.attributes.transactionId !== null)
             event_object.transaction_id = this.attributes.transactionId;
 
-        if (this.attributes.customerId !== undefined && this.attributes.customerId !== null)
-            event_object.customer_id = this.attributes.customerId;
+        if (this.attributes.externalCustomerId !== undefined && this.attributes.externalCustomerId !== null)
+            event_object.externalCustomerId = this.attributes.externalCustomerId;
 
         if (this.attributes.code !== undefined && this.attributes.code !== null)
             event_object.code = this.attributes.code;

--- a/lib/models/batch_event.js
+++ b/lib/models/batch_event.js
@@ -21,8 +21,8 @@ export default class BatchEvent {
         if (this.attributes.properties !== undefined && this.attributes.properties !== null)
             event_object.properties = this.attributes.properties;
 
-        if (this.attributes.subscriptionIds !== undefined && this.attributes.subscriptionIds !== null)
-            event_object.subscription_ids = this.attributes.subscriptionIds;
+        if (this.attributes.externalSubscriptionIds !== undefined && this.attributes.externalSubscriptionIds !== null)
+            event_object.external_subscription_ids = this.attributes.externalSubscriptionIds;
 
         let result = {
             event: event_object

--- a/lib/models/customer.js
+++ b/lib/models/customer.js
@@ -1,6 +1,6 @@
 export default class Customer {
     constructor(
-        customerId,
+        externalId,
         name,
         addressLine1 = null,
         addressLine2 = null,
@@ -17,7 +17,7 @@ export default class Customer {
         zipcode = null,
         billingConfiguration = null
     ) {
-        this.customerId = customerId,
+        this.externalId = externalId,
         this.name = name,
         this.addressLine1 = addressLine1,
         this.addressLine2 = addressLine2,
@@ -38,7 +38,7 @@ export default class Customer {
     wrapAttributes = function () {
         let result = {
             customer: {
-                customer_id: this.customerId,
+                external_id: this.externalId,
                 name: this.name,
                 address_line1: this.addressLine1,
                 address_line2: this.addressLine2,

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -21,8 +21,8 @@ export default class Event {
         if (this.attributes.properties !== undefined && this.attributes.properties !== null)
             event_object.properties = this.attributes.properties;
 
-        if (this.attributes.subscriptionId !== undefined && this.attributes.subscriptionId !== null)
-            event_object.subscription_id = this.attributes.subscriptionId;
+        if (this.attributes.externalSubscriptionId !== undefined && this.attributes.externalSubscriptionId !== null)
+            event_object.external_subscription_id = this.attributes.externalSubscriptionId;
 
         let result = {
             event: event_object

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -9,8 +9,8 @@ export default class Event {
         if (this.attributes.transactionId !== undefined && this.attributes.transactionId !== null)
             event_object.transaction_id = this.attributes.transactionId;
 
-        if (this.attributes.customerId !== undefined && this.attributes.customerId !== null)
-            event_object.customer_id = this.attributes.customerId;
+        if (this.attributes.externalCustomerId !== undefined && this.attributes.externalCustomerId !== null)
+            event_object.external_customer_id = this.attributes.externalCustomerId;
 
         if (this.attributes.code !== undefined && this.attributes.code !== null)
             event_object.code = this.attributes.code;

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -15,11 +15,8 @@ export default class Subscription {
         if (this.attributes.name !== undefined && this.attributes.name !== null)
             subscription_object.name = this.attributes.name;
 
-        if (this.attributes.subscriptionId !== undefined && this.attributes.subscriptionId !== null)
-            subscription_object.subscription_id = this.attributes.subscriptionId;
-
-        if (this.attributes.uniqueId !== undefined && this.attributes.uniqueId !== null)
-            subscription_object.unique_id = this.attributes.uniqueId;
+        if (this.attributes.externalId !== undefined && this.attributes.externalId !== null)
+            subscription_object.external_id = this.attributes.externalId;
 
         if (this.attributes.billingTime !== undefined && this.attributes.billingTime !== null)
             subscription_object.billingTime = this.attributes.billingTime;

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -6,8 +6,8 @@ export default class Subscription {
     wrapAttributes = function () {
         let subscription_object = {}
 
-        if (this.attributes.customerId !== undefined && this.attributes.customerId !== null)
-            subscription_object.customer_id = this.attributes.customerId;
+        if (this.attributes.externalCustomerId !== undefined && this.attributes.externalCustomerId !== null)
+            subscription_object.external_customer_id = this.attributes.externalCustomerId;
 
         if (this.attributes.planCode !== undefined && this.attributes.planCode !== null)
             subscription_object.plan_code = this.attributes.planCode;

--- a/test/applied_add_on.test.js
+++ b/test/applied_add_on.test.js
@@ -16,7 +16,7 @@ describe('Successfully sent apply coupon responds with 2xx', () => {
                     lago_id: "lago_id",
                     lago_add_on_id: "lago_add_on_id",
                     add_on_code: "add_on_code",
-                    customer_id: "testtest",
+                    external_customer_id: "testtest",
                     lago_customer_id: "lago_test_test",
                     amount_cents: 123,
                     amount_currency: "EUR",

--- a/test/applied_coupon.test.js
+++ b/test/applied_coupon.test.js
@@ -4,7 +4,7 @@ import Client from '../lib/client.js';
 import AppliedCoupon from '../lib/models/applied_coupon.js';
 
 let client = new Client('api_key')
-let appliedCoupon = new AppliedCoupon('customerId', 'coupon-code')
+let appliedCoupon = new AppliedCoupon('externalCustomerId', 'coupon-code')
 
 describe('Successfully sent apply coupon responds with 2xx', () => {
     before(() => {
@@ -16,7 +16,7 @@ describe('Successfully sent apply coupon responds with 2xx', () => {
                     lago_id: "b7ab2926-1de8-4428-9bcd-779314ac129b",
                     lago_coupon_id: "b7ab2926-1de8-4428-9bcd-779314ac129b",
                     coupon_code: "coupon-code",
-                    customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+                    external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
                     lago_customer_id: "99a6094e-199b-4101-896a-54e927ce7bd7",
                     amount_cents: 123,
                     amount_currency: "EUR",

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -62,30 +62,30 @@ describe('Current usage responds with a 2xx', () => {
     before(() => {
         nock.cleanAll()
         nock('https://api.getlago.com')
-            .get('/api/v1/customers/customer_id/current_usage?subscription_id=123')
+            .get('/api/v1/customers/external_customer_id/current_usage?subscription_id=123')
             .reply(200, {});
     });
 
     it('returns response', async () => {
-        let response = await client.customerCurrentUsage('customer_id', '123')
+        let response = await client.customerCurrentUsage('external_customer_id', '123')
 
         expect(response).to.be
     });
 });
 
 describe('Current usage responds with other than 2xx', () => {
-    let errorMessage = 'The HTTP status of the response: 404, URL: https://api.getlago.com/api/v1/customers/customer_id/current_usage?subscription_id=123'
+    let errorMessage = 'The HTTP status of the response: 404, URL: https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?subscription_id=123'
 
     before(() => {
         nock.cleanAll()
         nock('https://api.getlago.com')
-            .get('/api/v1/customers/customer_id/current_usage?subscription_id=123')
+            .get('/api/v1/customers/external_customer_id/current_usage?subscription_id=123')
             .reply(404);
     });
 
     it('raises an exception', async () => {
         try {
-            await client.customerCurrentUsage('customer_id', '123')
+            await client.customerCurrentUsage('external_customer_id', '123')
         } catch (err) {
             expect(err.message).to.eq(errorMessage)
         }

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -62,7 +62,7 @@ describe('Current usage responds with a 2xx', () => {
     before(() => {
         nock.cleanAll()
         nock('https://api.getlago.com')
-            .get('/api/v1/customers/external_customer_id/current_usage?subscription_id=123')
+            .get('/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123')
             .reply(200, {});
     });
 
@@ -74,12 +74,12 @@ describe('Current usage responds with a 2xx', () => {
 });
 
 describe('Current usage responds with other than 2xx', () => {
-    let errorMessage = 'The HTTP status of the response: 404, URL: https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?subscription_id=123'
+    let errorMessage = 'The HTTP status of the response: 404, URL: https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123'
 
     before(() => {
         nock.cleanAll()
         nock('https://api.getlago.com')
-            .get('/api/v1/customers/external_customer_id/current_usage?subscription_id=123')
+            .get('/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123')
             .reply(404);
     });
 

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -6,7 +6,7 @@ import BatchEvent from '../lib/models/batch_event.js';
 
 let client = new Client('api_key')
 let event = new Event({transactionId: 'transactionId', externalCustomerId: 'externalCustomerId', code: 'code'})
-let batchEvent = new BatchEvent({transactionId: 'transactionId', subscriptionIds: ['123', '456'], code: 'code'})
+let batchEvent = new BatchEvent({transactionId: 'transactionId', externalSubscriptionIds: ['123', '456'], code: 'code'})
 
 
 describe('Successfully sent event responds with 2xx', () => {

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -5,7 +5,7 @@ import Event from '../lib/models/event.js';
 import BatchEvent from '../lib/models/batch_event.js';
 
 let client = new Client('api_key')
-let event = new Event({transactionId: 'transactionId', customerId: 'customerId', code: 'code'})
+let event = new Event({transactionId: 'transactionId', externalCustomerId: 'externalCustomerId', code: 'code'})
 let batchEvent = new BatchEvent({transactionId: 'transactionId', subscriptionIds: ['123', '456'], code: 'code'})
 
 

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -5,7 +5,7 @@ import Subscription from '../lib/models/subscription.js';
 
 let client = new Client('api_key')
 let subscription = new Subscription(
-    {customerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", uniqueId: '123', billingTime: 'anniversary'}
+    {externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", uniqueId: '123', billingTime: 'anniversary'}
 )
 
 describe('Successfully sent subscription responds with 2xx', () => {
@@ -79,12 +79,12 @@ describe('Successfully sent subscription find all request with options responds 
     before(() => {
         nock.cleanAll()
         nock('https://api.getlago.com')
-            .get('/api/v1/subscriptions?customer_id=2')
+            .get('/api/v1/subscriptions?external_customer_id=2')
             .reply(200, {});
     });
 
     it('returns response', async () => {
-        let response = await client.findAllSubscriptions({customer_id: '2'})
+        let response = await client.findAllSubscriptions({external_customer_id: '2'})
 
         expect(response).to.be
     });

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -5,7 +5,7 @@ import Subscription from '../lib/models/subscription.js';
 
 let client = new Client('api_key')
 let subscription = new Subscription(
-    {externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", uniqueId: '123', billingTime: 'anniversary'}
+    {externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", externalId: '123', billingTime: 'anniversary'}
 )
 
 describe('Successfully sent subscription responds with 2xx', () => {


### PR DESCRIPTION
## Context

We want to clarify the difference between lago ids and external ids.

Today, we have `customer_id` on customers and `subscription_id|unique_id` on subscriptions.

On the API, the goal is to use external_ids:
- `external_id` or `external_customer_id` for customer
- `external_id` or `external_subscription_id` for subscription

## Description

The goal of this PR is to:
- rename `customer_id` to `external_id` on customers
- rename `subscription_id` to `external_id` on subscriptions
- remove `unique_id` from subscriptions
