### PR TITLE
feat(credit_notes): Add Credit note API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a Node.js wrapper for Lago API
 
 [![PyPI version](https://badge.fury.io/js/lago-nodejs-client.svg)](https://badge.fury.io/js/lago-nodejs-client)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 ## Installation
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import { createRequire } from 'module';
 import { isJSON } from './helpers/common.js';
+import { appendParams } from './helpers/parameters.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
@@ -139,11 +140,7 @@ export default class Client {
     }
 
     async findAllCustomers(options = null) {
-        let path = `/customers`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/customers?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/customers', options);
 
         let response;
         await this.apiRequest(path, 'get')
@@ -185,11 +182,7 @@ export default class Client {
     }
 
     async findAllInvoices(options = null){
-        let path = `/invoices`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/invoices?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/invoices', options);
 
         let response;
         await this.apiRequest(path, 'get')
@@ -225,11 +218,7 @@ export default class Client {
     }
 
     async findAllSubscriptions(options = null){
-        let path = `/subscriptions`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/subscriptions?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/subscriptions', options);
 
         let response;
         await this.apiRequest(path, 'get')
@@ -295,11 +284,7 @@ export default class Client {
     }
 
     async findAllBillableMetrics(options = null){
-        let path = `/billable_metrics`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/billable_metrics?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/billable_metrics', options);
 
         let response;
         await this.apiRequest(path, 'get')
@@ -343,15 +328,63 @@ export default class Client {
     }
 
     async findAllCoupons(options = null){
-        let path = `/coupons`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/coupons?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/coupons', options);
 
         let response;
         await this.apiRequest(path, 'get')
             .then(res => response = res.coupons);
+
+        return response;
+    }
+
+    // CREDIT NOTES
+
+    async createCreditNote(inputCreditNote) {
+        let response;
+        await this.apiRequest('/credit_notes', 'post', inputCreditNote.wrapAttributes())
+            .then(res => response = res.credit_note);
+
+        return response;
+    }
+
+    async updateCreditNote(inputCreditNote, identifier){
+        let response;
+        await this.apiRequest(`/credit_notes/${identifier}`, 'put', inputCreditNote.wrapAttributes())
+            .then(res => response = res.coupon);
+
+        return response;
+    }
+
+    async findCreditNote(identifier) {
+        let response;
+        await this.apiRequest(`/credit_notes/${identifier}`, 'get')
+            .then(res => response = res.credit_note);
+
+        return response;
+    }
+
+    async downloadCreditNote(input) {
+        let response;
+        await this.apiRequest(`/credit_notes/${input}/download`, 'post')
+            .then(res => response = res.credit_note);
+
+        return response;
+    }
+
+    async findAllCreditNotes(options = null) {
+        let path = appendParams('/credit_notes', options);
+
+        let response;
+        await this.apiRequest(path, 'get')
+            .then(res => response = res.credit_notes)
+
+        return response;
+    }
+
+    async voidCreditNote(input) {
+        let response;
+        await this.apiRequest(`/credit_notes/${input}/void`, 'put')
+            .then(res => response = res.credit_note);
 
         return response;
     }
@@ -391,11 +424,7 @@ export default class Client {
     }
 
     async findAllAddOns(options = null){
-        let path = `/add_ons`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/add_ons?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/add_ons', options);
 
         let response;
         await this.apiRequest(path, 'get')
@@ -465,11 +494,7 @@ export default class Client {
     }
 
     async findAllPlans(options = null){
-        let path = `/plans`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/plans?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/plans', options);
 
         let response;
         await this.apiRequest(path, 'get')
@@ -513,11 +538,7 @@ export default class Client {
     }
 
     async findAllWallets(options = null){
-        let path = `/wallets`
-
-        if (options !== null && JSON.stringify(options) !== '{}'){
-            path = `/wallets?${new URLSearchParams(options).toString()}`
-        }
+        let path = appendParams('/wallets', options);
 
         let response;
         await this.apiRequest(path, 'get')

--- a/lib/helpers/parameters.js
+++ b/lib/helpers/parameters.js
@@ -1,0 +1,9 @@
+export const appendParams = (path, params) => {
+    let result = path;
+
+    if (params !== null && JSON.stringify(params) !== '{}' ) {
+        result = `${path}?${new URLSearchParams(params).toString()}`
+    }
+
+    return result;
+}

--- a/lib/models/credit_note.js
+++ b/lib/models/credit_note.js
@@ -1,0 +1,61 @@
+import { isPresent } from "../helpers/common.js"
+
+export default class CreditNote {
+  constructor(attributes) {
+    this.attributes = attributes
+  }
+
+  wrapAttributes = function() {
+    let credit_note_object = {}
+
+    if (isPresent(this.attributes.invoiceId)) {
+      credit_note_object.invoice_id = this.attributes.invoiceId;
+    }
+
+    if (isPresent(this.attributes.reason)) {
+      credit_note_object.reason = this.attributes.reason;
+    }
+
+    if (isPresent(this.attributes.refundStatus)) {
+      credit_note_object.refund_status = this.attributes.refundStatus;
+    }
+
+    if (isPresent(this.attributes.creditAmountCents)) {
+      credit_note_object.credit_amount_cents = this.attributes.creditAmountCents;
+    }
+
+    if (isPresent(this.attributes.refundAmountCents)) {
+      credit_note_object.refund_amount_cents = this.attributes.refundAmountCents;
+    }
+
+    let result = {
+      credit_note: credit_note_object
+    }
+
+    if (isPresent(this.attributes.items)) {
+      result.credit_note.items = this.wrapItems();
+    }
+
+    return result;
+  }
+
+  wrapItems = function() {
+    if (!this.attributes.items) { return }
+
+    let output = this.attributes.items.map(item => {
+      let item_object = {};
+
+      if (isPresent(item.feeId)) {
+        item_object.fee_id = item.feeId;
+      }
+
+      if (isPresent(item.amountCents)) {
+        item_object.amount_cents = item.amountCents;
+      }
+
+      return item_object;
+    });
+
+    return output;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,20 +6,21 @@
   "type": "module",
   "exports": {
     ".": "./lib/client.js",
-    "./event": "./lib/models/event.js",
-    "./batch_event": "./lib/models/batch_event.js",
-    "./customer": "./lib/models/customer.js",
-    "./subscription": "./lib/models/subscription.js",
-    "./applied_coupon": "./lib/models/applied_coupon.js",
-    "./applied_add_on": "./lib/models/applied_add_on.js",
-    "./billable_metric": "./lib/models/billable_metric.js",
-    "./group": "./lib/models/group.js",
-    "./coupon": "./lib/models/coupon.js",
     "./add_on": "./lib/models/add_on.js",
-    "./plan": "./lib/models/plan.js",
+    "./applied_add_on": "./lib/models/applied_add_on.js",
+    "./applied_coupon": "./lib/models/applied_coupon.js",
+    "./batch_event": "./lib/models/batch_event.js",
+    "./billable_metric": "./lib/models/billable_metric.js",
+    "./billing_configuration": "./lib/models/billing_configuration.js",
     "./charge": "./lib/models/charge.js",
+    "./coupon": "./lib/models/coupon.js",
+    "./credit_note": "./lib/models/credit_note.js",
+    "./customer": "./lib/models/customer.js",
+    "./event": "./lib/models/event.js",
+    "./group": "./lib/models/group.js",
     "./organization": "./lib/models/organization.js",
-    "./billing_configuration": "./lib/models/billing_configuration.js"
+    "./plan": "./lib/models/plan.js",
+    "./subscription": "./lib/models/subscription.js"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha"

--- a/test/credit_note.test.js
+++ b/test/credit_note.test.js
@@ -1,0 +1,190 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import Client from "../lib/client.js";
+import CreditNote from '../lib/models/credit_note.js';
+
+let client = new Client('api_key')
+
+let creditNote = new CreditNote({
+  reason: 'other',
+  invoiceId: 'invoice-id',
+  items: [
+    {
+      feeId: 'fee-id',
+      creditAmountCents: 10,
+      refundAmountCents: 5,
+    }
+  ]
+})
+
+let response = {
+  credit_note: {
+    lago_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    sequential_id: 16,
+    number: "LAG15-CN16",
+    lago_invoice_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    invoice_number: "LAG15",
+    credit_status: "available",
+    refund_status: "pending",
+    reason: "overpaid",
+    total_amount_cents: 100,
+    total_amount_currency: "EUR",
+    credit_amount_cents: 100,
+    credit_amount_currency: "EUR",
+    balance_amount_cents: 100,
+    balance_amount_currency: "EUR",
+    refund_amount_cents: 100,
+    refund_amount_currency: "EUR",
+    created_at: "2022-10-04 16:21:00",
+    updated_at: "2022-10-04 16:21:00",
+    items: [
+      {
+        lago_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        fee: {
+          lago_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          item: {
+            type: "charge",
+            code: "seats",
+            name: "User Seats"
+          },
+          credit_amount_cents: 100,
+          credit_amount_currency: "EUR",
+          refund_amount_cents: 50,
+          refund_amount_currency: "EUR",
+          vat_amount_cents: 20,
+          vat_amount_currency: "EUR",
+          units: 12.6,
+          events_count: 4
+        }
+      }
+    ]
+  }
+}
+
+describe('Successfully create a credit note', () => {
+  before(() => {
+    nock.cleanAll()
+    nock('https://api.getlago.com')
+          .post('/api/v1/credit_notes')
+          .reply(200, response);
+  });
+
+  it('returns a 200', async() => {
+    let response = await client.createCreditNote(creditNote)
+
+    expect(response).to.be
+  })
+});
+
+describe('Failled create of credit note', () => {
+  let errorMessage = 'The HTTP status of the response: 422, URL: https://api.getlago.com/api/v1/credit_notes'
+
+  before(() => {
+    nock.cleanAll()
+    nock('https://api.getlago.com')
+      .post('/api/v1/credit_notes')
+      .reply(422);
+  });
+
+  it('raises an exception', async() => {
+    try {
+      await client.createCreditNote(creditNote);
+    } catch (err) {
+      expect(err.message).to.eq(errorMessage)
+    }
+  });
+});
+
+describe('Successfully sent credit note update request', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .put('/api/v1/credit_notes/credit-note-id')
+          .reply(200, {});
+  });
+
+  it('returns a 200', async () => {
+      let response = await client.updateCreditNote(creditNote, 'credit-note-id')
+
+      expect(response).to.be
+  });
+});
+
+describe('Failed update of credit note', () => {
+  let errorMessage = 'The HTTP status of the response: 422, URL: https://api.getlago.com/api/v1/credit_notes/credit-note-id';
+
+  before(() => {
+    nock.cleanAll()
+    nock('https://api.getlago.com')
+      .put('/api/v1/credit_notes/credit-note-id')
+      .reply(422);
+  });
+
+  it('raises an exception', async () => {
+    try {
+      await client.updateCreditNote(creditNote, 'credit-note-id');
+    } catch (err) {
+      expect(err.message).to.eq(errorMessage)
+    }
+  });
+});
+
+describe('Successfully find credit note request', () => {
+  before(() => {
+    nock.cleanAll()
+    nock('https://api.getlago.com')
+      .get('/api/v1/credit_notes/id')
+      .reply(200, {});
+  });
+
+  it ('returns a 200', async () => {
+    let response = await client.findCreditNote('id')
+
+    expect(response).to.be
+  });
+})
+
+describe('Successfully sent find all credit notes request', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .get('/api/v1/credit_notes')
+          .reply(200, {});
+  });
+
+  it('returns a 200', async () => {
+      let response = await client.findAllCreditNotes()
+
+      expect(response).to.be
+  });
+});
+
+describe('Successfully request invoice download', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .post('/api/v1/credit_notes/lago_id/download')
+          .reply(200, {});
+  });
+
+  it('returns a 200', async () => {
+      let response = await client.downloadCreditNote('lago_id')
+
+      expect(response).to.be
+  });
+});
+
+describe('Successfully sent find all credit notes request with options', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .get('/api/v1/credit_notes?per_page=2&page=3')
+          .reply(200, {});
+  });
+
+  it('returns 200', async () => {
+      let response = await client.findAllCreditNotes({per_page: 2, page: 3})
+
+      expect(response).to.be
+  });
+});


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the credit note API clients

Related to https://github.com/getlago/lago-api/pull/505