### PR TITLE
feat(groups): Add group on billable metric

### DIFF
--- a/lib/models/billable_metric.js
+++ b/lib/models/billable_metric.js
@@ -1,3 +1,5 @@
+import {isPresent} from '../helpers/common.js'
+
 export default class BillableMetric {
     constructor(attributes) {
         this.attributes = attributes
@@ -6,20 +8,12 @@ export default class BillableMetric {
     wrapAttributes = function () {
         let bm = {}
 
-        if (this.attributes.name !== undefined && this.attributes.name !== null)
-            bm.name = this.attributes.name;
-
-        if (this.attributes.code !== undefined && this.attributes.code !== null)
-            bm.code = this.attributes.code;
-
-        if (this.attributes.aggregationType !== undefined && this.attributes.aggregationType !== null)
-            bm.aggregation_type = this.attributes.aggregationType;
-
-        if (this.attributes.fieldName !== undefined && this.attributes.fieldName !== null)
-            bm.field_name = this.attributes.fieldName;
-
-        if (this.attributes.description !== undefined && this.attributes.description !== null)
-            bm.description = this.attributes.description;
+        if (isPresent(this.attributes.name)) bm.name = this.attributes.name;
+        if (isPresent(this.attributes.code)) bm.name = this.attributes.code;
+        if (isPresent(this.attributes.aggregationType)) bm.name = this.attributes.aggregationType;
+        if (isPresent(this.attributes.fieldName)) bm.name = this.attributes.fieldName;
+        if (isPresent(this.attributes.description)) bm.name = this.attributes.description;
+        if (isPresent(this.attributes.group)) bm.name = this.attributes.group;
 
         let result = {
             billable_metric: bm

--- a/test/billable_metric.test.js
+++ b/test/billable_metric.test.js
@@ -4,9 +4,17 @@ import Client from '../lib/client.js';
 import BillableMetric from '../lib/models/billable_metric.js';
 
 let client = new Client('api_key')
-let billableMetric = new BillableMetric({name: 'name1', code: 'code1', aggregationType: 'sum_agg',
-    fieldName: 'field_name'
+let billableMetric = new BillableMetric({
+    name: 'name1',
+    code: 'code1',
+    aggregationType: 'sum_agg',
+    fieldName: 'field_name',
+    group: {
+        key: 'country',
+        values: ["france", "italy", "spain"]
+    }
 })
+
 let response = {
     billable_metric: {
         lago_id: "b7ab2926-1de8-4428-9bcd-779314ac129b",
@@ -16,6 +24,10 @@ let response = {
         aggregation_type: "sum_agg",
         field_name: "field_name",
         created_at: "2022-04-29T08:59:51Z",
+        group: {
+            key: 'country',
+            values: ["france", "italy", "spain"]
+        }
     }
 }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds `group` on `billable_metric`.