### PR TITLE
feat (subscriptions): add support for subscription date param

### DIFF
--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -1,3 +1,5 @@
+import {isPresent} from "../helpers/common.js";
+
 export default class Subscription {
     constructor(attributes) {
         this.attributes = attributes
@@ -6,20 +8,12 @@ export default class Subscription {
     wrapAttributes = function () {
         let subscription_object = {}
 
-        if (this.attributes.externalCustomerId !== undefined && this.attributes.externalCustomerId !== null)
-            subscription_object.external_customer_id = this.attributes.externalCustomerId;
-
-        if (this.attributes.planCode !== undefined && this.attributes.planCode !== null)
-            subscription_object.plan_code = this.attributes.planCode;
-
-        if (this.attributes.name !== undefined && this.attributes.name !== null)
-            subscription_object.name = this.attributes.name;
-
-        if (this.attributes.externalId !== undefined && this.attributes.externalId !== null)
-            subscription_object.external_id = this.attributes.externalId;
-
-        if (this.attributes.billingTime !== undefined && this.attributes.billingTime !== null)
-            subscription_object.billingTime = this.attributes.billingTime;
+        if (isPresent(this.attributes.externalCustomerId)) subscription_object.external_customer_id = this.attributes.externalCustomerId;
+        if (isPresent(this.attributes.planCode)) subscription_object.plan_code = this.attributes.planCode;
+        if (isPresent(this.attributes.name)) subscription_object.name = this.attributes.name;
+        if (isPresent(this.attributes.externalId)) subscription_object.external_id = this.attributes.externalId;
+        if (isPresent(this.attributes.billingTime)) subscription_object.billing_time = this.attributes.billingTime;
+        if (isPresent(this.attributes.subscriptionDate)) subscription_object.subscription_date = this.attributes.subscriptionDate;
 
         let result = {
             subscription: subscription_object

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -5,7 +5,13 @@ import Subscription from '../lib/models/subscription.js';
 
 let client = new Client('api_key')
 let subscription = new Subscription(
-    {externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba", planCode: "eartha lynch", externalId: '123', billingTime: 'anniversary'}
+    {
+        externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+        planCode: "eartha lynch",
+        externalId: '123',
+        billingTime: 'anniversary',
+        subscriptionDate: '2022-08-08'
+    }
 )
 
 describe('Successfully sent subscription responds with 2xx', () => {


### PR DESCRIPTION
This PR adds support for `subscription_date` param when creating or updating subscription