### PR TITLE
feat(groups): Add group_properties on charge and groups endpoint

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -385,6 +385,22 @@ export default class Client {
         return response;
     }
 
+     // GROUPS
+
+    async findAllGroups(metricCode, options = null) {
+        let path = `/billable_metrics/${metricCode}/groups`
+
+        if (options !== null && JSON.stringify(options) !== '{}'){
+            path = `/billable_metrics/${metricCode}/groups?${new URLSearchParams(options).toString()}`
+        }
+
+        let response;
+        await this.apiRequest(path, 'get')
+            .then(res => response = res.groups)
+
+        return response;
+    }
+
     // ORGANIZATIONS
 
     async updateOrganization(inputOrganization){

--- a/lib/models/charge.js
+++ b/lib/models/charge.js
@@ -1,3 +1,5 @@
+import {isPresent} from '../helpers/common.js'
+
 export default class Charge {
     constructor(
         attributes
@@ -8,17 +10,11 @@ export default class Charge {
     wrapAttributes = function() {
         let result = {};
 
-        if (this.attributes.id !== undefined && this.attributes.id !== null)
-            result.id = this.attributes.id;
-
-        if (this.attributes.billableMetricId !== undefined && this.attributes.billableMetricId !== null)
-            result.billable_metric_id = this.attributes.billableMetricId;
-
-        if (this.attributes.chargeModel !== undefined && this.attributes.chargeModel !== null)
-            result.charge_model = this.attributes.chargeModel;
-
-        if (this.attributes.properties !== undefined && this.attributes.properties !== null)
-            result.properties = this.attributes.properties;
+        if (isPresent(this.attributes.id)) result.id = this.attributes.id;
+        if (isPresent(this.attributes.billableMetricId)) result.billable_metric_id = this.attributes.billableMetricId;
+        if (isPresent(this.attributes.chargeModel)) result.charge_model = this.attributes.chargeModel;
+        if (isPresent(this.attributes.properties)) result.properties = this.attributes.properties;
+        if (isPresent(this.attributes.groupProperties)) result.group_properties = this.attributes.groupProperties;
 
         return result;
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./applied_coupon": "./lib/models/applied_coupon.js",
     "./applied_add_on": "./lib/models/applied_add_on.js",
     "./billable_metric": "./lib/models/billable_metric.js",
+    "./group": "./lib/models/group.js",
     "./coupon": "./lib/models/coupon.js",
     "./add_on": "./lib/models/add_on.js",
     "./plan": "./lib/models/plan.js",

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import Client from "../lib/client.js";
+import BillableMetric from '../lib/models/billable_metric.js';
+
+let client = new Client('api_key')
+let billableMetric = new BillableMetric({name: 'name1', code: 'code1', aggregationType: 'sum_agg',
+    fieldName: 'field_name'
+})
+
+describe('Successfully sent find all groups request', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .get('/api/v1/billable_metrics/code1/groups')
+          .reply(200, {});
+  });
+
+  it('returns a 200', async () => {
+      let response = await client.findAllGroups('code1')
+
+      expect(response).to.be
+  });
+});
+
+describe('Successfully sent find all groups request with options', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .get('/api/v1/billable_metrics/code1/groups?per_page=2&page=3')
+          .reply(200, {});
+  });
+
+  it('returns 200', async () => {
+      let response = await client.findAllGroups('code1', {per_page: 2, page: 3})
+
+      expect(response).to.be
+  });
+});

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -31,7 +31,8 @@ let response = {
                 lago_billable_metric_id: 'id',
                 created_at: '2022-04-29T08:59:51Z',
                 charge_model: 'standard',
-                properties: {}
+                properties: {},
+                group_properties: []
             }
         ]
     }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds documentation for:
- `group_properties` on `charge` creation
- `GET billables_metrics/:code/groups` endpoint
