### PR TITLE
misc: Move fields to billing configuration

### DIFF
--- a/lib/models/customer.js
+++ b/lib/models/customer.js
@@ -14,7 +14,6 @@ export default class Customer {
         phone = null,
         state = null,
         url = null,
-        vatRate = null,
         zipcode = null,
         billingConfiguration = null,
     ) {
@@ -31,7 +30,6 @@ export default class Customer {
         this.phone = phone,
         this.state = state,
         this.url = url,
-        this.vatRate = vatRate,
         this.zipcode = zipcode,
         this.billingConfiguration = billingConfiguration
         this.currency = currency
@@ -53,7 +51,6 @@ export default class Customer {
                 phone: this.phone,
                 state: this.state,
                 url: this.url,
-                vat_rate: this.vatRate,
                 zipcode: this.zipcode,
                 currency: this.currency
             }

--- a/lib/models/customer_billing_configuration.js
+++ b/lib/models/customer_billing_configuration.js
@@ -1,12 +1,14 @@
-export default class BillingConfiguration {
+export default class CustomerBillingConfiguration {
   constructor(
     paymentProvider = null,
     providerCustomerId = null,
-    sync = null
+    sync = null,
+    vatRate = null
   ) {
     this.paymentProvider = paymentProvider,
     this.providerCustomerId = providerCustomerId,
-    this.sync = sync
+    this.sync = sync,
+    this.vatRate = vatRate
   }
 
   wrapAttributes = function() {
@@ -20,6 +22,9 @@ export default class BillingConfiguration {
 
     if (this.sync != undefined)
       result.sync = this.sync;
+
+    if (this.vatRate != undefined)
+      result.vat_rate = this.vatRate;
 
     return result;
   }

--- a/lib/models/organization.js
+++ b/lib/models/organization.js
@@ -9,9 +9,6 @@ export default class Organization {
         if (this.attributes.webhookUrl !== undefined && this.attributes.webhookUrl !== null)
             org_object.webhook_url = this.attributes.webhookUrl;
 
-        if (this.attributes.vatRate !== undefined && this.attributes.vatRate !== null)
-            org_object.vat_rate = this.attributes.vatRate;
-
         if (this.attributes.country !== undefined && this.attributes.country !== null)
             org_object.country = this.attributes.country;
 
@@ -39,13 +36,20 @@ export default class Organization {
         if (this.attributes.legalNumber !== undefined && this.attributes.legalNumber !== null)
             org_object.lega_number = this.attributes.legalNumber;
 
-        if (this.attributes.invoiceFooter !== undefined && this.attributes.invoiceFooter !== null)
-            org_object.invoice_footer = this.attributes.invoiceFooter;
-
         let result = {
             organization: org_object
         };
 
+        let billingConfiguration = this.wrapBillingAttributes();
+        if (billingConfiguration != undefined)
+            result.organization.billing_configuration = billingConfiguration;
+
         return result;
+    }
+
+    wrapBillingAttributes = function() {
+        if (!this.billingConfiguration) { return };
+
+        return this.billingConfiguration.wrapAttributes();
     }
 }

--- a/lib/models/organization_billing_configuration.js
+++ b/lib/models/organization_billing_configuration.js
@@ -1,0 +1,21 @@
+export default class OrganizationBillingConfiguration {
+  constructor(
+    invoiceFooter = null,
+    vatRate = null
+  ) {
+    this.invoiceFooter = invoiceFooter,
+    this.vatRate = vatRate
+  }
+
+  wrapAttributes = function() {
+    let result = {};
+
+    if (this.invoiceFooter != undefined)
+        result.invoice_footer = this.invoiceFooter;
+
+    if (this.vatRate != undefined)
+      result.vat_rate = this.vatRate;
+
+    return result;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lago-nodejs-client",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lago-nodejs-client",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "node-fetch": "^3.2.4"

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import nock from 'nock';
 import Client from '../lib/client.js';
 import Customer from '../lib/models/customer.js';
-import BillingConfiguration from '../lib/models/billing_configuration.js';
+import CustomerBillingConfiguration from '../lib/models/customer_billing_configuration.js';
 
 let client = new Client('api_key')
 let customer = new Customer(
@@ -22,7 +22,7 @@ let customer = new Customer(
     null,
     null,
     null,
-    new BillingConfiguration("stripe", "cus_12345"),
+    new CustomerBillingConfiguration("stripe", "cus_12345"),
 )
 
 describe('Successfully sent customer responds with 2xx', () => {

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -4,6 +4,7 @@ import Client from '../lib/client.js';
 
 let client = new Client('api_key')
 import Organization from '../lib/models/organization.js';
+import OrganizationBillingConfiguration from '../lib/models/organization_billing_configuration.js';
 
 describe('Successfully sent organization update status responds with 2xx', () => {
     before(() => {
@@ -14,7 +15,12 @@ describe('Successfully sent organization update status responds with 2xx', () =>
     });
 
     it('returns response', async () => {
-        let response = await client.updateOrganization(new Organization({webhookUrl: 'new url', vatRate: 15.5}))
+        let response = await client.updateOrganization(
+            new Organization({
+                webhookUrl: 'new url',
+                billingConfiguration: new OrganizationBillingConfiguration("footer", 15.5),
+            })
+        )
 
         expect(response).to.be
     });


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Description

The goal of this PR is to move fields related to Billing or Invoice into `billing_configuration`.

For customer: `vat_rate`.

For organization: `invoice_footer`, `vat_rate`.
