### PR TITLE
feat(grace_period): Rename invoice#status to payment_status

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -154,10 +154,10 @@ export default class Client {
 
     // INVOICES
 
-    async updateInvoiceStatus(input){
+    async updateInvoicePaymentStatus(input){
         let body = {
             invoice: {
-                status: input.status || null
+                paymentStatus: input.paymentStatus || null
             }
         }
 

--- a/test/invoice.test.js
+++ b/test/invoice.test.js
@@ -4,7 +4,7 @@ import Client from '../lib/client.js';
 
 let client = new Client('api_key')
 
-describe('Successfully sent invoice update status responds with 2xx', () => {
+describe('Successfully sent invoice update payment status responds with 2xx', () => {
     before(() => {
         nock.cleanAll()
         nock('https://api.getlago.com')
@@ -13,7 +13,7 @@ describe('Successfully sent invoice update status responds with 2xx', () => {
     });
 
     it('returns response', async () => {
-        let response = await client.updateInvoiceStatus({lagoId: 'lago_id', status: 'succeeded'})
+        let response = await client.updateInvoicePaymentStatus({lagoId: 'lago_id', paymentStatus: 'succeeded'})
 
         expect(response).to.be
     });
@@ -31,7 +31,7 @@ describe('Status code is not 2xx', () => {
 
     it('raises an exception', async () => {
         try {
-            await client.updateInvoiceStatus({lagoId: 'lago_id', status: 'succeeded'})
+            await client.updateInvoicePaymentStatus({lagoId: 'lago_id', paymentStatus: 'succeeded'})
         } catch (err) {
             expect(err.message).to.eq(errorMessage)
         }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to rename `invoice#status` to `invoice#payment_status`.
`invoice#status` will be used to define if the invoice is `draft` or `finalized`.

**⚠️ This is a breaking change PR, do not merge before Dec. 8th.**
