### PR TITLE
feat(timezones): Update clients to support customer timezones

### DIFF
--- a/lib/models/coupon.js
+++ b/lib/models/coupon.js
@@ -13,7 +13,7 @@ export default class Coupon {
         if (isPresent(this.attributes.expiration)) coupon_object.expiration = this.attributes.expiration;
         if (isPresent(this.attributes.amountCents)) coupon_object.amount_cents = this.attributes.amountCents;
         if (isPresent(this.attributes.amountCurrency)) coupon_object.amount_currency = this.attributes.amountCurrency;
-        if (isPresent(this.attributes.expirationDate)) coupon_object.expiration_date = this.attributes.expirationDate;
+        if (isPresent(this.attributes.expirationAt)) coupon_object.expiration_at = this.attributes.expirationAt;
         if (isPresent(this.attributes.percentageRate)) coupon_object.percentage_rate = this.attributes.percentageRate;
         if (isPresent(this.attributes.couponType)) coupon_object.coupon_type = this.attributes.couponType;
         if (isPresent(this.attributes.reusable)) coupon_object.reusable = this.attributes.reusable;

--- a/lib/models/customer.js
+++ b/lib/models/customer.js
@@ -13,6 +13,7 @@ export default class Customer {
         logoUrl = null,
         phone = null,
         state = null,
+        timezone = null,
         url = null,
         zipcode = null,
         billingConfiguration = null,
@@ -29,6 +30,7 @@ export default class Customer {
         this.logoUrl = logoUrl,
         this.phone = phone,
         this.state = state,
+        this.timezone = timezone,
         this.url = url,
         this.zipcode = zipcode,
         this.billingConfiguration = billingConfiguration
@@ -50,6 +52,7 @@ export default class Customer {
                 logo_url: this.logoUrl,
                 phone: this.phone,
                 state: this.state,
+                timezone: this.timezone,
                 url: this.url,
                 zipcode: this.zipcode,
                 currency: this.currency

--- a/lib/models/organization.js
+++ b/lib/models/organization.js
@@ -36,6 +36,9 @@ export default class Organization {
         if (this.attributes.legalNumber !== undefined && this.attributes.legalNumber !== null)
             org_object.lega_number = this.attributes.legalNumber;
 
+        if (this.attributes.timezone !== undefined && this.attributes.timezone !== null)
+            org_object.timezone = this.attributes.timezone;
+
         let result = {
             organization: org_object
         };

--- a/lib/models/organization.js
+++ b/lib/models/organization.js
@@ -1,3 +1,5 @@
+import {isPresent} from "../helpers/common.js";
+
 export default class Organization {
     constructor(attributes) {
         this.attributes = attributes
@@ -6,38 +8,17 @@ export default class Organization {
     wrapAttributes = function () {
         let org_object = {}
 
-        if (this.attributes.webhookUrl !== undefined && this.attributes.webhookUrl !== null)
-            org_object.webhook_url = this.attributes.webhookUrl;
-
-        if (this.attributes.country !== undefined && this.attributes.country !== null)
-            org_object.country = this.attributes.country;
-
-        if (this.attributes.addressLine1 !== undefined && this.attributes.addressLine1 !== null)
-            org_object.address_line1 = this.attributes.addressLine1;
-
-        if (this.attributes.addressLine2 !== undefined && this.attributes.addressLine2 !== null)
-            org_object.address_line2 = this.attributes.addressLine2;
-
-        if (this.attributes.state !== undefined && this.attributes.state !== null)
-            org_object.state = this.attributes.state;
-
-        if (this.attributes.zipcode !== undefined && this.attributes.zipcode !== null)
-            org_object.zipcode = this.attributes.zipcode;
-
-        if (this.attributes.email !== undefined && this.attributes.email !== null)
-            org_object.email = this.attributes.email;
-
-        if (this.attributes.city !== undefined && this.attributes.city !== null)
-            org_object.city = this.attributes.city;
-
-        if (this.attributes.legalName !== undefined && this.attributes.legalName !== null)
-            org_object.legal_name = this.attributes.legalName;
-
-        if (this.attributes.legalNumber !== undefined && this.attributes.legalNumber !== null)
-            org_object.lega_number = this.attributes.legalNumber;
-
-        if (this.attributes.timezone !== undefined && this.attributes.timezone !== null)
-            org_object.timezone = this.attributes.timezone;
+        if (isPresent(this.attributes.webhookUrl)) org_object.webhook_url = this.attributes.webhookUrl;
+        if (isPresent(this.attributes.country)) org_object.country = this.attributes.country;
+        if (isPresent(this.attributes.addressLine1)) org_object.address_line1 = this.attributes.addressLine1;
+        if (isPresent(this.attributes.addressLine2)) org_object.address_line2 = this.attributes.addressLine2;
+        if (isPresent(this.attributes.state)) org_object.state = this.attributes.state;
+        if (isPresent(this.attributes.zipcode)) org_object.zipcode = this.attributes.zipcode;
+        if (isPresent(this.attributes.email)) org_object.email = this.attributes.email;
+        if (isPresent(this.attributes.city)) org_object.city = this.attributes.city;
+        if (isPresent(this.attributes.legalName)) org_object.legal_name = this.attributes.legalName;
+        if (isPresent(this.attributes.legalNumber)) org_object.lega_number = this.attributes.legalNumber;
+        if (isPresent(this.attributes.timezone)) org_object.timezone = this.attributes.timezone;
 
         let result = {
             organization: org_object

--- a/lib/models/wallet.js
+++ b/lib/models/wallet.js
@@ -13,7 +13,7 @@ export default class Wallet {
         if (isPresent(this.attributes.name)) wallet_object.name = this.attributes.name;
         if (isPresent(this.attributes.paidCredits)) wallet_object.paid_credits = this.attributes.paidCredits;
         if (isPresent(this.attributes.grantedCredits)) wallet_object.granted_credits = this.attributes.grantedCredits;
-        if (isPresent(this.attributes.expirationDate)) wallet_object.expiration_date = this.attributes.expirationDate;
+        if (isPresent(this.attributes.expirationAt)) wallet_object.expiration_at = this.attributes.expirationAt;
 
         let result = {
             wallet: wallet_object

--- a/test/coupon.test.js
+++ b/test/coupon.test.js
@@ -15,7 +15,7 @@ let response = {
         expiration: "no_expiration",
         amount_cents: 1000,
         amount_currency: "EUR",
-        expiration_date: null,
+        expiration_at: null,
         frequency: "once",
         frequency_duration: null,
         coupon_type: "fixed_amount",

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -6,23 +6,23 @@ import CustomerBillingConfiguration from '../lib/models/customer_billing_configu
 
 let client = new Client('api_key')
 let customer = new Customer(
-    "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
-    "Gavin Belson",
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    new CustomerBillingConfiguration("stripe", "cus_12345"),
+    "5eb02857-a71e-4ea2-bcf9-57d8885990ba", // externalId
+    "Gavin Belson", // name
+    null, // addressLine1
+    null, // addressLine2
+    null, // city
+    null, // country
+    null, // currency
+    null, // email
+    null, // legalName
+    null, // legalNumber
+    null, // logoUrl
+    null, // phone
+    null, // state
+    null, // timezone
+    null, // url
+    null, // zipcode
+    new CustomerBillingConfiguration("stripe", "cus_12345"), // billingConfiguration
 )
 
 describe('Successfully sent customer responds with 2xx', () => {

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -14,7 +14,7 @@ let response = {
         external_customer_id: "external-123",
         rate_amount: "1",
         balance: "200",
-        expiration_date: "2022-07-07",
+        expiration_at: "2022-07-07T23:59:59Z",
         created_at: "2022-04-29T08:59:51Z",
     }
 }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR adds:
- Support for timezone at customer level
- Support for timezone at organization level
- Replace `expiration_date` by `expiration_at` on coupons
- Replace `expiration_date` by `expiration_at` on wallets
