### PR TITLE
feat(delete_bm): Update response and tests for billable metric deletion

### DIFF
--- a/test/billable_metric.test.js
+++ b/test/billable_metric.test.js
@@ -27,7 +27,9 @@ let response = {
         group: {
             key: 'country',
             values: ["france", "italy", "spain"]
-        }
+        },
+        active_subscriptions_count: 0,
+        draft_invoices_count: 0
     }
 }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric response:
- `activeSubscriptionsCount`
- `draftInvoicesCount`

These fields are used to know the impact of deleting billable metric.