### PR TITLE
feat(delete_customer): Add the destroy customer route

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -149,6 +149,14 @@ export default class Client {
         return response;
     }
 
+    async destroyCustomer(externalCustomerId) {
+        let response;
+        await this.apiRequest(`/customers/${externalCustomerId}`, 'delete')
+            .then(res => response = res.customer);
+
+        return response;
+    }
+
     // INVOICES
 
     async updateInvoicePaymentStatus(input){

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -97,3 +97,18 @@ describe('Current usage responds with other than 2xx', () => {
         }
     });
 });
+
+describe('Successfully sent customer destroy request', () => {
+    before(() => {
+        nock.cleanAll()
+        nock('https://api.getlago.com')
+            .delete('/api/v1/customers/5eb02857-a71e-4ea2-bcf9-57d8885990ba')
+            .reply(200, {});
+    });
+
+    it('returns the deleted customers', async () => {
+        let response = await client.destroyCustomer('5eb02857-a71e-4ea2-bcf9-57d8885990ba')
+
+        expect(response).to.be
+    });
+});


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds the new customer destroy route