### PR TITLE
feat(delete_coupon): Ability to destroy an applied coupon

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -91,6 +91,14 @@ export default class Client {
       return response;
     }
 
+    async destroyAppliedCoupon(externalCustomerId, couponCode) {
+        let response;
+        await this.apiRequest(`/customers/${externalCustomerId}/coupons/${couponCode}`, 'delete')
+            .then(res => response = res.applied_coupon);
+
+        return response;
+    }
+
     async createEvent(inputEvent){
         let response;
         await this.apiRequest(`/events`, 'post', inputEvent.wrapAttributes())

--- a/test/applied_coupon.test.js
+++ b/test/applied_coupon.test.js
@@ -85,3 +85,18 @@ describe('Successfully sent applied coupon find all request with options respond
     expect(response).to.be
   });
 });
+
+describe('Successfully sent applied coupon destroy request', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .delete('/api/v1/customers/5eb02857-a71e-4ea2-bcf9-57d8885990ba/coupons/code')
+          .reply(200, {});
+  });
+
+  it('returns the deleted applied coupon', async () => {
+      let response = await client.destroyAppliedCoupon('5eb02857-a71e-4ea2-bcf9-57d8885990ba', 'code')
+
+      expect(response).to.be
+  });
+});


### PR DESCRIPTION
**Context**
Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete an applied coupon.

**Description**
This PR adds the destroy endpoint for applied coupon.