### PR TITLE
feat(instant_charge): Add API route to show a fee

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -473,7 +473,17 @@ export default class Client {
         return response;
     }
 
-     // GROUPS
+    // FEES
+
+    async findFee(identifier) {
+        let response;
+        await this.apiRequest(`/fees/${identifier}`, 'get')
+            .then(res => response = res.fee);
+
+        return response;
+    }
+
+    // GROUPS
 
     async findAllGroups(metricCode, options = null) {
         let path = `/billable_metrics/${metricCode}/groups`

--- a/test/fee.test.js
+++ b/test/fee.test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import Client from '../lib/client.js';
+
+let client = new Client('api_key')
+
+describe('Successfully sent fee find request responds with 2xx', () => {
+  before(() => {
+      nock.cleanAll()
+      nock('https://api.getlago.com')
+          .get('/api/v1/fees/fee-1')
+          .reply(200, {});
+  });
+
+  it('returns response', async () => {
+      let response = await client.findFee('fee-1')
+
+      expect(response).to.be
+  });
+});


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new route to retrieve a single fee via the API (`GET /api/v1/fees/:id`)

Related to https://github.com/getlago/lago-api/pull/866