### PR TITLE
feat(instant_charge): Ability to define charge as instant

### DIFF
--- a/lib/models/charge.js
+++ b/lib/models/charge.js
@@ -13,6 +13,7 @@ export default class Charge {
         if (isPresent(this.attributes.id)) result.id = this.attributes.id;
         if (isPresent(this.attributes.billableMetricId)) result.billable_metric_id = this.attributes.billableMetricId;
         if (isPresent(this.attributes.chargeModel)) result.charge_model = this.attributes.chargeModel;
+        if (isPresent(this.attributes.instant)) result.instant = this.attributes.instant;
         if (isPresent(this.attributes.properties)) result.properties = this.attributes.properties;
         if (isPresent(this.attributes.groupProperties)) result.group_properties = this.attributes.groupProperties;
 

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -5,8 +5,11 @@ import Plan from '../lib/models/plan.js';
 import Charge from '../lib/models/charge.js';
 
 let client = new Client('api_key')
-let charge = new Charge({billableMetricId: 'billable_metric_id', amountCurrency: 'EUR',
-        chargeModel: 'standard'
+let charge = new Charge({
+    billableMetricId: 'billable_metric_id',
+    amountCurrency: 'EUR',
+    chargeModel: 'standard',
+    instant: false
 })
 let charges = [charge]
 let plan = new Plan({name: 'name1', code: 'code1', interval: 'weekly', amountCents: 1000,
@@ -33,6 +36,7 @@ let response = {
                 lago_billable_metric_id: 'id',
                 created_at: '2022-04-29T08:59:51Z',
                 charge_model: 'standard',
+                instant: false,
                 properties: {},
                 group_properties: []
             }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR allows having an instant charge.