### PR TITLE
feat(bm): Expose count of attached plans

### DIFF
--- a/test/billable_metric.test.js
+++ b/test/billable_metric.test.js
@@ -29,7 +29,8 @@ let response = {
             values: ["france", "italy", "spain"]
         },
         active_subscriptions_count: 0,
-        draft_invoices_count: 0
+        draft_invoices_count: 0,
+        plan_count: 0
     }
 }
 

--- a/test/billable_metric.test.js
+++ b/test/billable_metric.test.js
@@ -30,7 +30,7 @@ let response = {
         },
         active_subscriptions_count: 0,
         draft_invoices_count: 0,
-        plan_count: 0
+        plans_count: 0
     }
 }
 

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -31,6 +31,7 @@ let response = {
             {
                 lago_id: 'id',
                 lago_billable_metric_id: 'id',
+                billable_metric_code: 'bm_code',
                 created_at: '2022-04-29T08:59:51Z',
                 charge_model: 'standard',
                 properties: {},


### PR DESCRIPTION
## Context

Plans edition has some issue if you update some properties of a billable metric, especially if you change groups definition or aggregation type :

"After the billable metric edition, new dimensions are created with new group_id that do not match the ones in the plans already defined"

## Description

This PR exposes a new `plans_count` field in the `BillableMetric` response type to let the API users know if the BM is editable.

Related to https://github.com/getlago/lago-api/pull/914
